### PR TITLE
Minimal CI

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -15,5 +15,7 @@ jobs:
         java-version: 17
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+    - name: Missing Wrapper Workaround
+      run: gradle wrapper --gradle-version 8.12 --distribution-type all
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -1,0 +1,19 @@
+name: build-plugin
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 17
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+    - name: Build with Gradle
+      run: ./gradlew build


### PR DESCRIPTION
This adds a minimal CI to validate pull requests. Not sure whether the gradle wrapper is missing intentionally from this repository - the additional step to fix this runs as long as the actual build, so I would propose to add the wrapper and drop the step.

Note that no artifacts are captured as of yet.